### PR TITLE
Propoer ffi_lib include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.0.7 (11/13/2015)
+  * Propoer ffi_lib include -- patch by tboerger
 # 0.0.6 (03/08/2014)
   * Upgrade FFI to 1.9.3 -- patch by esbeka
 # 0.0.5 (01/21/2014)

--- a/lib/archive/libarchive.rb
+++ b/lib/archive/libarchive.rb
@@ -130,7 +130,7 @@ module Archive # :nodoc:
     elsif ::FFI::Platform.mac? and File.exist?('/opt/local/lib/libarchive.dylib')
       self.linked_archive_library = '/opt/local/lib/libarchive.dylib'
     else
-      self.linked_archive_library = 'archive'
+      self.linked_archive_library = ['archive', 'libarchive.so.13']
     end
 
     ffi_lib self.linked_archive_library

--- a/lib/archive/version.rb
+++ b/lib/archive/version.rb
@@ -1,3 +1,3 @@
 module Archive
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
As documented on
https://github.com/ffi/ffi/wiki/Loading-Libraries#linux-packages we
should use a proper ffi_lib parameter because the *.so files are not
part of the regular packages on many distributions. With that patch we
are able to just install libarchive13 instead of libarchive-devel as a
runtime dependency on openSUSE/SLES.

This change is required to be able to use this gem on a SLES server.